### PR TITLE
Facilitate zimbra command execution on the server

### DIFF
--- a/src/java/features/CommandLineUtilitiesTest.feature
+++ b/src/java/features/CommandLineUtilitiesTest.feature
@@ -1,0 +1,6 @@
+
+@cli
+Feature: CommandLineUtilities
+  Scenario: Use zmprov commands
+    Given Create '10' bulk accounts with mask 'cat' on domain 'zdev-vm002.eng.zimbra.com'
+    Given Create Single account with username 'Auto' and password 'test123' on domain 'zdev-vm002.eng.zimbra.com' with attributes 'default'

--- a/src/java/stepDefinitions/zimbra/createDatastepdef.java
+++ b/src/java/stepDefinitions/zimbra/createDatastepdef.java
@@ -1,0 +1,52 @@
+package stepDefinitions.zimbra;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.When;
+import exception.HarnessException;
+import stepDefinitions.BaseStepDefs;
+import utilities.CommandLineUtilities;
+
+public class createDatastepdef extends BaseStepDefs {
+
+    private Scenario scenario;
+
+    @Before
+    public void beforeChangePasswordMutations(Scenario scenario) {
+        this.scenario = scenario;
+    }
+
+    @When("^Create '(.+)' bulk accounts with mask '(.+)' on domain '(.+)'$")
+    public void createBulkAccounts(int count, String mask, String domain) {
+        String host = globalProperties.getProperty("server");
+        int port = new Integer(globalProperties.getProperty("port"));
+        String user = globalProperties.getProperty("serverUser");
+        String password = globalProperties.getProperty("serverPassword");
+        String command = "su - zimbra -c 'zmprov cabulk " + domain + " " + mask + " " + count + "'";
+        scenario.write("Command being executed :" + command);
+        String output = CommandLineUtilities.executeCommand(host, port, user, password, command);
+        if (output == null) {
+            throw new HarnessException("CLI failed");
+        }
+        scenario.write(output);
+    }
+
+    @When("^Create Single account with username '(.+)' and password '(.+)' on domain '(.+)' with attributes '(.+)'$")
+    public void createSingleAccount(String userName, String userPassword, String domain, String attributes) {
+        String host = globalProperties.getProperty("server");
+        if (attributes.equals("default")) {
+            attributes = "";
+        }
+        int port = new Integer(globalProperties.getProperty("port"));
+        String serverUser = globalProperties.getProperty("serverUser");
+        String serverPassword = globalProperties.getProperty("serverPassword");
+        String command = "su - zimbra -c 'zmprov ca " + userName + "@" + domain + " " + userPassword + " " + attributes + "'";
+        scenario.write("Command being executed :" + command);
+        String output = CommandLineUtilities.executeCommand(host, port, serverUser, serverPassword, command);
+        if (output == null) {
+            throw new HarnessException("CLI failed");
+        }
+        scenario.write(output);
+    }
+
+}

--- a/src/java/utilities/CommandLineUtilities.java
+++ b/src/java/utilities/CommandLineUtilities.java
@@ -1,0 +1,55 @@
+package utilities;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Properties;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+
+public class CommandLineUtilities {
+
+    public static JSch jsch = new JSch();
+    public static Properties config = new Properties();
+
+    public static String executeCommand(String host, int port, String user, String password, String command) {
+        config.put("StrictHostKeyChecking", "no");
+        ArrayList<String> out = new ArrayList<String>();
+        if (host.isEmpty() || user.isEmpty() || password.isEmpty() || command.isEmpty()) {
+            return null;
+        }
+        try {
+            Session session = jsch.getSession(user, host, port);
+            session.setPassword(password);
+            session.setConfig(config);
+            session.connect();
+            Channel channel = session.openChannel("exec");
+            ((ChannelExec) channel).setCommand(command);
+            channel.setInputStream(null);
+            ((ChannelExec) channel).setErrStream(System.err);
+
+            InputStream in = channel.getInputStream();
+            channel.connect();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                out.add(line);
+            }
+            channel.disconnect();
+            session.disconnect();
+        } catch (JSchException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        return out.toString();
+    }
+
+}

--- a/src/java/utilities/CommandLineUtilities.java
+++ b/src/java/utilities/CommandLineUtilities.java
@@ -1,7 +1,6 @@
 package utilities;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
@@ -9,8 +8,9 @@ import java.util.Properties;
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
+
+import exception.HarnessException;
 
 public class CommandLineUtilities {
 
@@ -42,12 +42,8 @@ public class CommandLineUtilities {
             }
             channel.disconnect();
             session.disconnect();
-        } catch (JSchException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+        } catch (Exception e) {
+            throw new HarnessException(e.getMessage());
         }
         return out.toString();
     }


### PR DESCRIPTION
To allow execution on zimbra commands on the server below changes were made.
src/java/utilities/CommandLineUtilities.java has method executeCommand that can be used to execute any command on the server.
Username, password and port number needs to be provided for the same.
Screenshot of the sample report : 
![image](https://user-images.githubusercontent.com/15122239/51517357-715a6300-1e40-11e9-99ce-6b9b764888a4.png)
