### PR TITLE
ZCS-6943:Add gql automation for freebusy query

### DIFF
--- a/src/java/features/freeBusy.feature
+++ b/src/java/features/freeBusy.feature
@@ -1,0 +1,33 @@
+@freeBusy
+Feature: FreeBusy Query
+
+  Scenario Outline: Setup config
+    Given Application url '<server>' and path '<path>'
+    And Request headers '<headers>'
+
+    Examples: 
+      | server       | path        | headers                                               | account | username | password | method | status | valid | authToken       |
+      | zimbraServer | gqlEndpoint | Accept:application/json,Content-type:application/json | account | admin    | test123  | post   |    200 | valid | zimbraAuthToken |
+
+  Scenario Outline: Create Test appointments
+    When Get '<account>' '<authToken>' authToken for username '<user1>' and password '<password>' using '<method>' method
+    Then set AuthToken in the cookie
+    Then User '<user1>' schedules an appointment '<subject>' with user '<user2>' from '<startTime>' to '<endTime>'
+
+    Examples: 
+      | account | user1                           | password | method | authToken       | user2                           | subject       | startTime       | endTime         |
+      | account | admin@zdev-vm002.eng.zimbra.com | test123  | post   | zimbraAuthToken | test2@zdev-vm002.eng.zimbra.com | test_subject1 | 20190318T093000 | 20190318T103000 |
+      | account | test2@zdev-vm002.eng.zimbra.com | test123  | post   | zimbraAuthToken | admin@zdev-vm002.eng.zimbra.com | test_subject2 | 20190318T103000 | 20190318T113000 |
+
+  Scenario Outline: FreeBusy Query
+    When Get '<account>' '<authToken>' authToken for username '<user>' and password '<password>' using '<method>' method
+    Then set AuthToken in the cookie
+    When FreeBusy status is queried for user '<user>' for startTime '<sTime>' and endTime '<eTime>'
+    Then Timeslot '<timeslot1>' - '<timeslot2>' should be marked as '<status>'
+
+    Examples: 
+      | account | authToken       | method | sTime         | eTime         | user                            | password | status | timeslot1     | timeslot2     |
+      | account | zimbraAuthToken | post   | 1552847400000 | 1552933800000 | test2@zdev-vm002.eng.zimbra.com | test123  | f      | 1552847400000 | 1552915800000 |
+      | account | zimbraAuthToken | post   | 1552847400000 | 1552933800000 | test2@zdev-vm002.eng.zimbra.com | test123  | t      | 1552915800000 | 1552919400000 |
+      | account | zimbraAuthToken | post   | 1552847400000 | 1552933800000 | test2@zdev-vm002.eng.zimbra.com | test123  | b      | 1552919400000 | 1552923000000 |
+      | account | zimbraAuthToken | post   | 1552847400000 | 1552933800000 | test2@zdev-vm002.eng.zimbra.com | test123  | f      | 1552923000000 | 1552933800000 |

--- a/src/java/stepDefinitions/zimbra/AppointmentStepDefs.java
+++ b/src/java/stepDefinitions/zimbra/AppointmentStepDefs.java
@@ -1,0 +1,108 @@
+package stepDefinitions.zimbra;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import harness.HarnessContext;
+import net.minidev.json.JSONObject;
+import stepDefinitions.BaseStepDefs;
+/**
+ * @author swapnil.pingle
+ *
+ */
+public class AppointmentStepDefs extends BaseStepDefs{
+    
+    private Scenario scenario;
+    private HarnessContext context;
+    private List<Map> emailAddresses;
+    private List<Map> attendees;
+    private Map<String,Object> message;
+    private Map<String,Object> tEmailAddress;
+    private Map<String,Object> sEmailAddress;
+    private Map<String,Object> mimePart;
+    private Map<String,Object> invite;
+    private Map<String,Object> organizer;
+    private Map<String,Object> startDate;
+    private Map<String,Object> endDate;
+    private Map<String,Object> attendee;
+    private String apptCreateMutation;
+    
+    public AppointmentStepDefs(){
+        emailAddresses = new ArrayList<Map>();
+        attendees = new ArrayList<Map>();
+        message = new HashMap<String,Object>();
+        tEmailAddress = new HashMap<String,Object>();
+        sEmailAddress = new HashMap<String,Object>();
+        mimePart = new HashMap<String,Object>();
+        invite = new HashMap<String,Object>();
+        organizer = new HashMap<String,Object>();
+        startDate = new HashMap<String,Object>();
+        endDate = new HashMap<String,Object>();
+        attendee = new HashMap<String,Object>();
+        apptCreateMutation = "'query':'mutation createAppt($vMessage:MessageInput){appointmentCreate(message: $vMessage){calendarInviteId}}'";
+    }
+    
+    public AppointmentStepDefs(HarnessContext context) {
+        this();
+        this.context = context;
+    }
+    
+    @Before
+    public void BeforeSearchFolderMutations(Scenario scenario) {
+        this.scenario = scenario;
+    }
+    @Given("^User '(.+)' schedules an appointment '(.+)' with user '(.+)' from '(.+)' to '(.+)'$")
+    public void createAppointment(String vOrganizer, String vSubject, String vAttendee, String startTime, String endTime){
+        // EmailAddress
+        tEmailAddress.put("addressType", "t");
+        tEmailAddress.put("address", vAttendee);
+        sEmailAddress.put("addressType", "s");
+        sEmailAddress.put("address", vOrganizer);
+        emailAddresses.add(tEmailAddress);
+        emailAddresses.add(sEmailAddress);
+        //mimePart
+        mimePart.put("contentType", "text/plain");
+        mimePart.put("content", "HI this is a test");
+        //invite.orgnizer
+        organizer.put("address", vOrganizer);
+        //invite.startDate
+        startDate.put("dateTime", startTime);
+        //invite.endDate
+        endDate.put("dateTime", endTime);
+        //invite.attendee
+        attendee.put("address", vAttendee);
+        attendee.put("participationStatus", "NE");
+        attendee.put("rsvp", true);
+        attendees.add(attendee);
+        //invite
+        invite.put("name", vSubject);
+        invite.put("description","just a simple test");
+        invite.put("organizer",organizer);
+        invite.put("isAllDay", false);
+        invite.put("startDate", startDate);
+        invite.put("endDate", endDate);
+        invite.put("attendees", attendees);
+        //message
+        message.put("subject", vSubject);
+        message.put("emailAddresses", emailAddresses);
+        message.put("mimePart", mimePart);
+        message.put("invite", invite);
+        //mutation
+        Map<String, Object> variables = new HashMap<String,Object>();
+        variables.put("vMessage", message);
+        
+        JSONObject json = new JSONObject(variables);
+        String variable = "'variables':" + json.toJSONString();
+        
+        String requestBody = "{" + apptCreateMutation + " , " + variable + "}";
+        logger.info(requestBody);
+        System.out.println(requestBody);
+        scenario.write("Query being processed :" + requestBody);
+        baseline.processRequest(context, requestBody, "Post");
+    }
+}

--- a/src/java/stepDefinitions/zimbra/FreeBusyStepDefsQuery.java
+++ b/src/java/stepDefinitions/zimbra/FreeBusyStepDefsQuery.java
@@ -1,0 +1,79 @@
+package stepDefinitions.zimbra;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import cucumber.api.Scenario;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.When;
+import harness.HarnessContext;
+import harness.utils.StringUtils;
+import junit.framework.Assert;
+import junit.framework.AssertionFailedError;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import stepDefinitions.BaseStepDefs;
+
+/**
+ * @author swapnil.pingle
+ *
+ */
+public class FreeBusyStepDefsQuery extends BaseStepDefs{
+    private Scenario scenario;
+    private Map<String, Object> fbQueryMap;
+    private String fbQuery;
+    private StringUtils stringUtils;
+    private HarnessContext context;
+    
+    public FreeBusyStepDefsQuery(){
+        fbQueryMap = new HashMap<String,Object>();
+        String q = "'query':'query fb($vStartTime:Long!, $vEndTime:Long!, $vFreeBusyUsers:String){freeBusy(startTime:$vStartTime, endTime:$vEndTime, freeBusyUsers: {name:$vFreeBusyUsers}){elements{startTime,endTime,status},identifier}}'";
+        fbQuery = q;
+        stringUtils = new StringUtils();
+    }
+    
+    public FreeBusyStepDefsQuery(HarnessContext context) {
+        this();
+        this.context = context;
+    }
+    
+    @Before
+    public void BeforeSearchFolderMutations(Scenario scenario) {
+        this.scenario = scenario;
+    }
+    
+    @When("^FreeBusy status is queried for user '(.+)' for startTime '(.+)' and endTime '(.+)'$")
+    public void verifyFreeBusySlots(String user, String sTime, String eTime){
+        fbQueryMap.put("vStartTime", sTime);
+        fbQueryMap.put("vEndTime", eTime);
+        fbQueryMap.put("vFreeBusyUsers", user);
+        
+        JSONObject json = new JSONObject(fbQueryMap);
+        System.out.println(json.toJSONString());
+        
+        String variables = "'variables':"+json.toJSONString();
+        
+        String requestBody = "{" + fbQuery + " , " + variables +"}";
+        logger.info(requestBody);
+        System.out.println(requestBody);
+        scenario.write("Query being processed :" + requestBody);
+        baseline.processRequest(context, requestBody, "Post");
+        String jsonPath = "data.freeBusy[?(@.identifier=='" + user + "')].identifier";
+        Assert.assertEquals("Verify if identifier matches provided user",user, baseline.getValues(context, jsonPath).get(0));
+    }
+    
+    @When("^Timeslot '(.+)' - '(.+)' should be marked as '(.+)'$")
+    public void verifyTimeSlotwiseStatus(String slot1, String slot2, String expStatus){
+        String jsonPath = "data.freeBusy[0].elements[?(@.startTime==" + slot1 + ")]";
+        JSONArray output = baseline.getValues(context, jsonPath);
+        if ( output.size() == 0){
+            throw new AssertionFailedError("No timeslot details matching start time "+slot1);
+        } else if (output.size() > 1) {
+            scenario.write("More than one data found for start time "+slot1);
+        } else {
+            LinkedHashMap contents = (LinkedHashMap)output.get(0);
+            Assert.assertEquals("Verify if expected and actual status match",expStatus, contents.get("status"));
+            Assert.assertEquals("Verify if expected and actual endTime match",new Long(slot2), contents.get("endTime"));
+        }
+    }
+}


### PR DESCRIPTION
Two dummy appointments have been created to validate tentative , busy and free status response for freebusy query.

Below is the execution report for reference:
[cucumber-reports.zip](https://github.com/Zimbra/zm-api-test-harness/files/3012951/cucumber-reports.zip)
