### PR TITLE
Bugfix/zcs 7766: Add gql automation for admin auth, create account and modify account mutations

### DIFF
--- a/global.properties
+++ b/global.properties
@@ -1,6 +1,7 @@
 server = zdev-vm002.eng.zimbra.com
 scheme = https
 gqlEndpoint = /service/extension/graphql
+gqlAdminEndpoint = /service/extension/graphql-admin
 port = 22
 serverUser = root
 serverPassword = zimbra

--- a/ivy.xml
+++ b/ivy.xml
@@ -21,5 +21,6 @@
 	<dependency org="net.minidev" name="json-smart" rev="2.2"/>
 	<dependency org="org.hamcrest" name="hamcrest-core" rev="1.3"/>
 	<dependency org="com.jcraft" name="jsch" rev="0.1.53"/>
+	<dependency org="com.google.code.gson" name="gson" rev="2.8.0" />
  </dependencies>
 </ivy-module>

--- a/src/java/baseLine/Baseline.java
+++ b/src/java/baseLine/Baseline.java
@@ -35,6 +35,7 @@ public class Baseline {
 	private static HttpResponse response;
 	public static CloseableHttpResponse executionResponse;
 	public static final String authCookieName = "ZM_AUTH_TOKEN";
+	public static final String adminAuthCookieName = "ZM_ADMIN_AUTH_TOKEN";
 	private static HarnessClient harnessClient;
 	private StringUtils stringUtils;
 	private long startTime;
@@ -182,5 +183,18 @@ public class Baseline {
 		}
 		return false;
 	}
+
+	public boolean isAdminAuthTokenPresent(HarnessContext context) {
+	        harnessClient = context.getHarnessClient();
+	        List<Cookie> cookieList = harnessClient.getCookieStore().getCookies();
+	        if (!cookieList.isEmpty()) {
+	            for (Cookie currentCookie : cookieList) {
+	                if (currentCookie.getName().equals(adminAuthCookieName)) {
+	                    return (!stringUtils.isEmpty(currentCookie.getValue()));
+	                }
+	            }
+	        }
+	        return false;
+	    }
 
 }

--- a/src/java/features/Admin/Account/createAccount.feature
+++ b/src/java/features/Admin/Account/createAccount.feature
@@ -1,0 +1,31 @@
+@createAccount
+Feature: Create account mutation
+
+  Scenario Outline: Log in with admin user
+    Given Application url '<server>' and path '<path>'
+    And Request headers '<headers>'
+    When Generate admin authToken for user '<username>' and password '<password>'
+    Then set adminAuthToken in the cookie
+
+    Examples: 
+      | server       | path             | headers                                               | username | password | status | valid | authToken       |
+      | zimbraServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
+
+  Scenario Outline: Create account
+    Given adminAuthToken is present in the cookies
+    When Create user with name '<name>' password '<password>' attribute '<attributes>'
+    Then Validate account is created/modified with attributes '<attributes>'
+
+    Examples: 
+      | name          | password | attributes                                                                      |
+      | account1@host | test123  | zimbraAccountStatus=active, zimbraQuotaWarnPercent=20                           |
+      | account2@host | test123  | zimbraFeatureMobileSyncEnabled=FALSE, zimbraMailForwardingAddressMaxLength=2048 |
+
+  Scenario Outline: Create account
+    Given adminAuthToken is present in the cookies
+    When Create user account with name '<name>' password '<password>'
+    Then Validate account is created/modified with attributes '<attributes>'
+
+    Examples: 
+      | name          | password | attributes                                            |
+      | account1@host | test123  | zimbraAccountStatus=active, zimbraQuotaWarnPercent=90 |

--- a/src/java/features/Admin/Account/modifyAccount.feature
+++ b/src/java/features/Admin/Account/modifyAccount.feature
@@ -1,0 +1,22 @@
+@modifyAccount
+Feature: Modify account mutation
+
+  Scenario Outline: Log in with admin user
+    Given Application url '<server>' and path '<path>'
+    And Request headers '<headers>'
+    When Generate admin authToken for user '<username>' and password '<password>'
+    Then set adminAuthToken in the cookie
+
+    Examples: 
+      | server       | path             | headers                                               | username | password | status | valid | authToken       |
+      | zimbraServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
+
+  Scenario Outline: Modify account
+    Given adminAuthToken is present in the cookies
+    And Create user account with name '<name>' password '<password>'
+    When Attributes '<attributes>' are modified for user '<name>'
+    Then Validate account is created/modified with attributes '<attributes>'
+
+    Examples: 
+      | name          | password | attributes                                            |
+      | account1@host | test123  | zimbraAccountStatus=pending, zimbraQuotaWarnPercent=20 |

--- a/src/java/features/Admin/Auth/adminAuth.feature
+++ b/src/java/features/Admin/Auth/adminAuth.feature
@@ -1,0 +1,14 @@
+Feature: SearchFolder Mutation, Query
+
+  @adminAuth
+  Scenario Outline: Log in with user account
+    Given Application url '<server>' and path '<path>'
+    And Request headers '<headers>'
+    When Generate admin authToken for user '<username>' and password '<password>'
+    Then Validate status is '<status>'
+    And Validate token is '<valid>' '<authToken>' token
+
+    Examples: 
+      | server       | path             | headers                                               | account | username | password        | status | valid   | authToken       |
+      | zimbraServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin   | admin    | test123         |    200 | valid   | zimbraAuthToken |
+      | zimbraServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin   | admin    | invalidPassword |    200 | invalid | zimbraAuthToken |

--- a/src/java/features/Admin/Auth/adminAuth.feature
+++ b/src/java/features/Admin/Auth/adminAuth.feature
@@ -1,7 +1,7 @@
-Feature: SearchFolder Mutation, Query
+@adminAuth
+Feature: Admin auth mutation
 
-  @adminAuth
-  Scenario Outline: Log in with user account
+  Scenario Outline: Validate authentication for admin account
     Given Application url '<server>' and path '<path>'
     And Request headers '<headers>'
     When Generate admin authToken for user '<username>' and password '<password>'

--- a/src/java/stepDefinitions/AccountStepdefs.java
+++ b/src/java/stepDefinitions/AccountStepdefs.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.http.client.methods.HttpPost;
+
 import cucumber.api.Scenario;
 import cucumber.api.java.Before;
 import cucumber.api.java.en.Given;
@@ -50,7 +52,7 @@ public class AccountStepdefs extends BaseStepDefs {
         String variable = var.toJSONString();
         String variables = "'variables': " + variable;
         String requestBody = "{" + createMutation + " , " + variables + "}";
-        HttpResponse response = baseline.processRequest(context, requestBody, "POST");
+        HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
         context.setResponse(response);
     }
     
@@ -85,7 +87,7 @@ public class AccountStepdefs extends BaseStepDefs {
         String variable = var.toJSONString();
         String variables = "'variables': " + variable;
         String requestBody = "{" + createMutation + " , " + variables + "}";
-        HttpResponse response = baseline.processRequest(context, requestBody, "POST");
+        HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
         context.setResponse(response);
     }
     
@@ -99,7 +101,7 @@ public class AccountStepdefs extends BaseStepDefs {
         String variable = var.toJSONString();
         String variables = "'variables': " + variable;
         String requestBody = "{" + modifyMutation + " , " + variables + "}";
-        HttpResponse response = baseline.processRequest(context, requestBody, "POST");
+        HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
         context.setResponse(response);
     }
 

--- a/src/java/stepDefinitions/AccountStepdefs.java
+++ b/src/java/stepDefinitions/AccountStepdefs.java
@@ -1,0 +1,124 @@
+package stepDefinitions;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import harness.HarnessContext;
+import harness.HttpResponse;
+import junit.framework.Assert;
+import net.minidev.json.JSONObject;
+
+public class AccountStepdefs extends BaseStepDefs {
+    private String createMutation;
+    private String modifyMutation;
+    private Scenario scenario;
+    private HarnessContext context;
+    
+    public AccountStepdefs(){
+        createMutation = "'query':'mutation ca($password:String, $name:String!, $attributes:[AttrInput]){accountCreate(name:$name, password:$password, attributes:$attributes){ account{ id,  attrList{ key, value}} }}'";
+        modifyMutation = "'query':'mutation ca($id:String!, $attributes:[AttrInput]){accountModify(id:$id, attributes:$attributes){ account{ id, name , attrList{ key, value}} }}'";
+    }
+    
+    public AccountStepdefs(HarnessContext context) {
+        this();
+        this.context = context;
+    }
+    @Before
+    public void beforeAccount(Scenario scenario){
+        this.scenario = scenario;
+    }
+    
+    @Given("^Create user with name '(.+)' password '(.+)' attribute '(.+)'$")
+    public void createAccount(String name, String password, String attrList) {
+        HashMap<String,Object> varMap = new HashMap<String,Object>();
+        List<Object> attributes = setAttributes(attrList);
+        varMap.put("attributes", attributes);
+        varMap.put("password", password);
+        if(name.contains("host")){
+            String domain = globalProperties.getProperty("server").trim();
+            String randomName = name.split("@")[0] + generateRandomInt();
+            name = randomName+"@"+domain;
+        }
+        varMap.put("name", name); 
+        JSONObject var = new JSONObject(varMap);
+        String variable = var.toJSONString();
+        String variables = "'variables': " + variable;
+        String requestBody = "{" + createMutation + " , " + variables + "}";
+        HttpResponse response = baseline.processRequest(context, requestBody, "POST");
+        context.setResponse(response);
+    }
+    
+    @Then("^Validate account is created/modified with attributes '(.+)'$")
+    public void validateAccountAttributes(String attributes){
+        String[] attrs = attributes.split(",");
+        for(String current : attrs){
+            String[] keyValue = current.split("=");
+            String attribute = keyValue[0].trim();
+            String expValue = keyValue[1].trim();
+            //data.accountCreate.account.attrList
+            String accountAttrPath = context.getResponse().getBody().jsonString().contains("accountCreate")? "data.accountCreate.account.attrList":"data.accountModify.account.attrList";
+            String jsonPath = accountAttrPath+"[?(@.key=='"+attribute+"')].value";
+            String actValue = baseline.getValue(context, jsonPath);
+            scenario.write("Actual value in the response: "+actValue);
+            scenario.write("Expected value: [\""+expValue+"\"]");
+            Assert.assertEquals("[\""+expValue+"\"]", actValue);
+        }
+    }
+
+    @Given("^Create user account with name '(.+)' password '(.+)'$")
+    public void createAccountNoAttrs(String name, String password) {
+        HashMap<String,Object> varMap = new HashMap<String,Object>();
+        varMap.put("password", password);
+        if(name.contains("host")){
+            String domain = globalProperties.getProperty("server").trim();
+            String randomName = name.split("@")[0] + generateRandomInt();
+            name = randomName+"@"+domain;
+        }
+        varMap.put("name", name); 
+        JSONObject var = new JSONObject(varMap);
+        String variable = var.toJSONString();
+        String variables = "'variables': " + variable;
+        String requestBody = "{" + createMutation + " , " + variables + "}";
+        HttpResponse response = baseline.processRequest(context, requestBody, "POST");
+        context.setResponse(response);
+    }
+    
+    @Then("^Attributes '(.+)' are modified for user '(.+)'$")
+    public void modifyAccount(String attrList, String name){
+        HashMap<String,Object> varMap = new HashMap<String,Object>();
+        List<Object> attributes = setAttributes(attrList);
+        varMap.put("attributes", attributes);
+        varMap.put("id", readIDfromResponse());
+        JSONObject var = new JSONObject(varMap);
+        String variable = var.toJSONString();
+        String variables = "'variables': " + variable;
+        String requestBody = "{" + modifyMutation + " , " + variables + "}";
+        HttpResponse response = baseline.processRequest(context, requestBody, "POST");
+        context.setResponse(response);
+    }
+
+    private String readIDfromResponse() {
+        String jsonPath = context.getResponse().getBody().jsonString().contains("accountCreate")?"data.accountCreate.account.id":"data.accountModify.account.id";
+        return baseline.getValue(context, jsonPath);
+    }
+    
+    private List<Object> setAttributes(String attrlist) {
+        List<Object> attrList = new ArrayList<Object>();
+        
+        for(String current: attrlist.split(",")){
+            Map<String,Object> attrs = new HashMap<String,Object>();
+            String[] currentAttr = current.trim().split("=");
+            attrs.put("key",currentAttr[0].trim());
+            attrs.put("value", currentAttr[1].trim());
+            attrList.add(attrs);
+        }
+        return attrList;
+    }
+
+}

--- a/src/java/stepDefinitions/AdminAuthMutationStepDefs.java
+++ b/src/java/stepDefinitions/AdminAuthMutationStepDefs.java
@@ -3,6 +3,7 @@ package stepDefinitions;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.http.client.methods.HttpPost;
 import org.junit.Assert;
 
 import cucumber.api.Scenario;
@@ -60,7 +61,7 @@ public class AdminAuthMutationStepDefs extends BaseStepDefs {
         String requestBody = "{" + authMutation + " , " + variables + "}";
         System.out.println(requestBody);
         logger.info(requestBody);
-        baseline.processRequest(context, requestBody, "POST");
+        baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
         authToken = baseline.getValue(context, authTokenJsonPath);
         scenario.write("AuthToken returned is :" + authToken);
 

--- a/src/java/stepDefinitions/AdminAuthMutationStepDefs.java
+++ b/src/java/stepDefinitions/AdminAuthMutationStepDefs.java
@@ -89,9 +89,7 @@ public class AdminAuthMutationStepDefs extends BaseStepDefs {
                 if (validity.equalsIgnoreCase("valid")) {
                     Assert.assertTrue("Verify that JWT token '" + authToken + "' is valid", size == 3);
                 } else {
-                    // Assert.assertFalse("Verify that JWT token is valid", size
-                    // ==
-                    // 3);
+                    // Assert.assertFalse("Verify that JWT token is valid", size == 3);
                 }
                 break;
             case "zimbraAuthToken":

--- a/src/java/stepDefinitions/AdminAuthMutationStepDefs.java
+++ b/src/java/stepDefinitions/AdminAuthMutationStepDefs.java
@@ -1,0 +1,110 @@
+package stepDefinitions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import exception.HarnessException;
+import harness.HarnessContext;
+import harness.utils.StringUtils;
+import net.minidev.json.JSONObject;
+
+/**
+ * @author swapnil.pingle
+ *
+ */
+public class AdminAuthMutationStepDefs extends BaseStepDefs {
+
+    private String authMutation;
+    public static String authToken;
+    private String authTokenJsonPath = "data.authenticate.authToken";
+    private Scenario scenario;
+    private StringUtils stringUtils;
+    private HarnessContext context;
+
+    public AdminAuthMutationStepDefs() {
+        authMutation = "'query':'mutation auth($authInput:AdminAuthRequestInput!){ authenticate(authInput: $authInput) { authToken, csrfToken, lifetime }}'";
+        stringUtils = new StringUtils();
+    }
+
+    public AdminAuthMutationStepDefs(HarnessContext context) {
+        this();
+        this.context = context;
+    }
+
+    @Before
+    public void BeforeBaseLine(Scenario scenario) {
+        this.scenario = scenario;
+    }
+
+    @When("^Generate admin authToken for user '(.+)' and password '(.+)'$")
+    public void authRequestUserNamePassword(String username, String password) {
+
+        Map<String, Object> authInput = new HashMap<String, Object>();
+        Map<String, Object> account = new HashMap<String, Object>();
+        Map<String, Object> varMap = new HashMap<String, Object>();
+        account.put("accountBy", "name");
+        account.put("key", username);
+        authInput.put("account", account);
+        authInput.put("password", password);
+        varMap.put("authInput", authInput);
+        JSONObject json = new JSONObject(varMap);
+        String authenticate = json.toJSONString();
+        String variables = "'variables': " + authenticate;
+        String requestBody = "{" + authMutation + " , " + variables + "}";
+        System.out.println(requestBody);
+        logger.info(requestBody);
+        baseline.processRequest(context, requestBody, "POST");
+        authToken = baseline.getValue(context, authTokenJsonPath);
+        scenario.write("AuthToken returned is :" + authToken);
+
+    }
+    @Given("^set adminAuthToken in the cookie$")
+    public void setAuthToken() throws HarnessException {
+        if (!stringUtils.isEmpty(authToken)) {
+            baseline.setCookies(context, "ZM_ADMIN_AUTH_TOKEN", authToken);
+        } else {
+            throw new HarnessException("Something went wrong! Empty authToken returned.");
+        }
+    }
+    
+    @Then("^Validate token is '(.+)' '(.+)' token$")
+    public void validateToken(String validity, String type){
+
+        scenario.write("Fetched authToken for type '" + type + "' is '" + authToken + "'");
+        int size = authToken.split("\\.").length;
+        if (validity.equalsIgnoreCase("valid")) {
+            if (stringUtils.isEmpty(authToken)) {
+                throw new HarnessException("Something went wrong! Empty authToken returned.");
+            }
+            switch (type) {
+            case "JWT":
+                if (validity.equalsIgnoreCase("valid")) {
+                    Assert.assertTrue("Verify that JWT token '" + authToken + "' is valid", size == 3);
+                } else {
+                    // Assert.assertFalse("Verify that JWT token is valid", size
+                    // ==
+                    // 3);
+                }
+                break;
+            case "zimbraAuthToken":
+            default:
+                Assert.assertTrue("Verify that zimbraAuth token '" + authToken + "' is valid", size == 1);
+                break;
+            }
+        } else {
+            Assert.assertEquals("For invalid data empty authToken should be returned", "", authToken);
+        }
+    }
+
+    @Given("^adminAuthToken is present in the cookies$")
+    public void checkAuthTokenExists() throws Exception {
+        Assert.assertTrue("Check if cookie contains authToken", baseline.isAdminAuthTokenPresent(context));
+    }
+}

--- a/src/java/stepDefinitions/BaseStepDefs.java
+++ b/src/java/stepDefinitions/BaseStepDefs.java
@@ -1,16 +1,16 @@
 package stepDefinitions;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.Random;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import baseLine.Baseline;
 
 /**
@@ -55,6 +55,10 @@ public class BaseStepDefs {
             user = name + "@" + domain;
         }
         return user;
+    }
+
+    public int generateRandomInt(){
+        return new Random().nextInt(100000);
     }
 
 }

--- a/src/java/stepDefinitions/BaseStepDefs.java
+++ b/src/java/stepDefinitions/BaseStepDefs.java
@@ -10,7 +10,6 @@ import java.util.Properties;
 import java.util.Random;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import baseLine.Baseline;
 
 /**
@@ -60,5 +59,4 @@ public class BaseStepDefs {
     public int generateRandomInt(){
         return new Random().nextInt(100000);
     }
-
 }


### PR DESCRIPTION
Automation added for auth, create account and modify account mutations.

Please unzip attached report and open index.html to view report.
[cucumber-reports.zip](https://github.com/Zimbra/zm-api-test-harness/files/3545395/cucumber-reports.zip)
