### PR TITLE
Bugfix/zcs 7793

### DIFF
--- a/global.properties
+++ b/global.properties
@@ -1,8 +1,8 @@
-server = zdev-vm002.eng.zimbra.com
+server = ec2-35-154-223-151.ap-south-1.compute.amazonaws.com
 scheme = https
 gqlEndpoint = /service/extension/graphql
 gqlAdminEndpoint = /service/admin/extension/graphql-admin
 port = 22
-adminPort = 9071
+adminPort = 31071
 serverUser = root
 serverPassword = zimbra

--- a/global.properties
+++ b/global.properties
@@ -1,7 +1,7 @@
 server = zdev-vm002.eng.zimbra.com
 scheme = https
 gqlEndpoint = /service/extension/graphql
-gqlAdminEndpoint = /service/extension/graphql-admin
+gqlAdminEndpoint = /service/admin/extension/graphql-admin
 port = 22
 adminPort = 9071
 serverUser = root

--- a/global.properties
+++ b/global.properties
@@ -1,4 +1,5 @@
 server = ec2-35-154-223-151.ap-south-1.compute.amazonaws.com
+domain = zmc.com
 scheme = https
 gqlEndpoint = /service/extension/graphql
 gqlAdminEndpoint = /service/admin/extension/graphql-admin

--- a/global.properties
+++ b/global.properties
@@ -3,5 +3,6 @@ scheme = https
 gqlEndpoint = /service/extension/graphql
 gqlAdminEndpoint = /service/extension/graphql-admin
 port = 22
+adminPort = 9071
 serverUser = root
 serverPassword = zimbra

--- a/src/java/features/Admin/Account/createAccount.feature
+++ b/src/java/features/Admin/Account/createAccount.feature
@@ -14,7 +14,7 @@ Feature: Create account mutation
   Scenario Outline: Create account
     Given adminAuthToken is present in the cookies
     When Create user with name '<name>' password '<password>' attribute '<attributes>'
-    Then Validate account is created/modified with attributes '<attributes>'
+    Then Validate account has attributes '<attributes>'
 
     Examples: 
       | name          | password | attributes                                                                      |
@@ -24,7 +24,7 @@ Feature: Create account mutation
   Scenario Outline: Create account
     Given adminAuthToken is present in the cookies
     When Create user account with name '<name>' password '<password>'
-    Then Validate account is created/modified with attributes '<attributes>'
+    Then Validate account has attributes '<attributes>'
 
     Examples: 
       | name          | password | attributes                                            |

--- a/src/java/features/Admin/Account/createAccount.feature
+++ b/src/java/features/Admin/Account/createAccount.feature
@@ -9,7 +9,7 @@ Feature: Create account mutation
 
     Examples: 
       | server       | path             | headers                                               | username | password | status | valid | authToken       |
-      | zimbraServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
+      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
 
   Scenario Outline: Create account
     Given adminAuthToken is present in the cookies

--- a/src/java/features/Admin/Account/createAccount.feature
+++ b/src/java/features/Admin/Account/createAccount.feature
@@ -8,8 +8,8 @@ Feature: Create account mutation
     Then set adminAuthToken in the cookie
 
     Examples: 
-      | server       | path             | headers                                               | username | password | status | valid | authToken       |
-      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
+      | server            | path             | headers                                               | username | password | status | valid | authToken       |
+      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin@host    | test123  |    200 | valid | zimbraAuthToken |
 
   Scenario Outline: Create account
     Given adminAuthToken is present in the cookies

--- a/src/java/features/Admin/Account/deleteAccount.feature
+++ b/src/java/features/Admin/Account/deleteAccount.feature
@@ -8,8 +8,8 @@ Feature: Delete account mutation
     Then set adminAuthToken in the cookie
 
     Examples: 
-      | server       | path             | headers                                               | username | password | status | valid | authToken       |
-      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
+      | server            | path             | headers                                               | username   | password | status | valid | authToken       |
+      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin@host | test123  |    200 | valid | zimbraAuthToken |
 
   Scenario Outline: Delete account
     Given adminAuthToken is present in the cookies

--- a/src/java/features/Admin/Account/deleteAccount.feature
+++ b/src/java/features/Admin/Account/deleteAccount.feature
@@ -13,7 +13,8 @@ Feature: Delete account mutation
 
   Scenario Outline: Delete account
     Given adminAuthToken is present in the cookies
-    When Create and Delete user account with name '<name>' password '<password>'
+    When Create user account with name '<name>' password '<password>'
+    When Delete user account with name '<name>'
     Then Validate account is deleted
 
     Examples: 

--- a/src/java/features/Admin/Account/deleteAccount.feature
+++ b/src/java/features/Admin/Account/deleteAccount.feature
@@ -9,7 +9,7 @@ Feature: Delete account mutation
 
     Examples: 
       | server       | path             | headers                                               | username | password | status | valid | authToken       |
-      | zimbraServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
+      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
 
   Scenario Outline: Delete account
     Given adminAuthToken is present in the cookies

--- a/src/java/features/Admin/Account/getAccount.feature
+++ b/src/java/features/Admin/Account/getAccount.feature
@@ -13,9 +13,10 @@ Feature: Get account mutation
 
   Scenario Outline: Create and Get account
     Given adminAuthToken is present in the cookies
-    And Create and Get user with name '<name>' password '<password>' attribute '<attributes>'
+    And Create user account with name '<name>' password '<password>'
+    Then Get user account with name '<name>' attribute '<attributes>'
     Then Validate account has attributes '<attributes>'
 
     Examples: 
       | name          | password | attributes                                             |
-      | account1@host | test123  | zimbraAccountStatus=pending, zimbraQuotaWarnPercent=20 |
+      | account1@host | test123  | zimbraAccountStatus=active, zimbraQuotaWarnPercent=90 |

--- a/src/java/features/Admin/Account/getAccount.feature
+++ b/src/java/features/Admin/Account/getAccount.feature
@@ -8,9 +8,8 @@ Feature: Get account mutation
     Then set adminAuthToken in the cookie
 
     Examples: 
-      | server       | path             | headers                                               | username | password | status | valid | authToken       |
-      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
-
+      | server            | path             | headers                                               | username   | password | status | valid | authToken       |
+      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin@host | test123  |    200 | valid | zimbraAuthToken |
 
   Scenario Outline: Create and Get account
     Given adminAuthToken is present in the cookies
@@ -18,5 +17,5 @@ Feature: Get account mutation
     Then Validate account has attributes '<attributes>'
 
     Examples: 
-      | name | password            | attributes                                                                        |
+      | name          | password | attributes                                             |
       | account1@host | test123  | zimbraAccountStatus=pending, zimbraQuotaWarnPercent=20 |

--- a/src/java/features/Admin/Account/getAccount.feature
+++ b/src/java/features/Admin/Account/getAccount.feature
@@ -15,7 +15,7 @@ Feature: Get account mutation
   Scenario Outline: Create and Get account
     Given adminAuthToken is present in the cookies
     And Create and Get user with name '<name>' password '<password>' attribute '<attributes>'
-    Then Validate account is created/modified/get with attributes '<attributes>'
+    Then Validate account has attributes '<attributes>'
 
     Examples: 
       | name | password            | attributes                                                                        |

--- a/src/java/features/Admin/Account/getAccount.feature
+++ b/src/java/features/Admin/Account/getAccount.feature
@@ -9,7 +9,7 @@ Feature: Get account mutation
 
     Examples: 
       | server       | path             | headers                                               | username | password | status | valid | authToken       |
-      | zimbraServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
+      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
 
 
   Scenario Outline: Create and Get account

--- a/src/java/features/Admin/Account/modifyAccount.feature
+++ b/src/java/features/Admin/Account/modifyAccount.feature
@@ -9,7 +9,7 @@ Feature: Modify account mutation
 
     Examples: 
       | server       | path             | headers                                               | username | password | status | valid | authToken       |
-      | zimbraServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
+      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
 
   Scenario Outline: Modify account
     Given adminAuthToken is present in the cookies

--- a/src/java/features/Admin/Account/modifyAccount.feature
+++ b/src/java/features/Admin/Account/modifyAccount.feature
@@ -8,8 +8,8 @@ Feature: Modify account mutation
     Then set adminAuthToken in the cookie
 
     Examples: 
-      | server       | path             | headers                                               | username | password | status | valid | authToken       |
-      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin    | test123  |    200 | valid | zimbraAuthToken |
+      | server            | path             | headers                                               | username   | password | status | valid | authToken       |
+      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin@host | test123  |    200 | valid | zimbraAuthToken |
 
   Scenario Outline: Modify account
     Given adminAuthToken is present in the cookies
@@ -18,5 +18,5 @@ Feature: Modify account mutation
     Then Validate account has attributes '<attributes>'
 
     Examples: 
-      | name          | password | attributes                                            |
+      | name          | password | attributes                                             |
       | account1@host | test123  | zimbraAccountStatus=pending, zimbraQuotaWarnPercent=20 |

--- a/src/java/features/Admin/Account/modifyAccount.feature
+++ b/src/java/features/Admin/Account/modifyAccount.feature
@@ -15,7 +15,7 @@ Feature: Modify account mutation
     Given adminAuthToken is present in the cookies
     And Create user account with name '<name>' password '<password>'
     When Attributes '<attributes>' are modified for user '<name>'
-    Then Validate account is created/modified with attributes '<attributes>'
+    Then Validate account has attributes '<attributes>'
 
     Examples: 
       | name          | password | attributes                                            |

--- a/src/java/features/Admin/Auth/adminAuth.feature
+++ b/src/java/features/Admin/Auth/adminAuth.feature
@@ -10,5 +10,5 @@ Feature: Admin auth mutation
 
     Examples: 
       | server       | path             | headers                                               | account | username | password        | status | valid   | authToken       |
-      | zimbraServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin   | admin    | test123         |    200 | valid   | zimbraAuthToken |
-      | zimbraServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin   | admin    | invalidPassword |    200 | invalid | zimbraAuthToken |
+      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin   | admin    | test123         |    200 | valid   | zimbraAuthToken |
+      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin   | admin    | invalidPassword |    200 | invalid | zimbraAuthToken |

--- a/src/java/features/Admin/Auth/adminAuth.feature
+++ b/src/java/features/Admin/Auth/adminAuth.feature
@@ -9,6 +9,6 @@ Feature: Admin auth mutation
     And Validate token is '<valid>' '<authToken>' token
 
     Examples: 
-      | server       | path             | headers                                               | account | username | password        | status | valid   | authToken       |
-      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin   | admin    | test123         |    200 | valid   | zimbraAuthToken |
-      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin   | admin    | invalidPassword |    200 | invalid | zimbraAuthToken |
+      | server            | path             | headers                                               | account    | username   | password        | status | valid   | authToken       |
+      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin@host | admin@host | test123         |    200 | valid   | zimbraAuthToken |
+      | zimbraAdminServer | gqlAdminEndpoint | Accept:application/json,Content-type:application/json | admin@host | admin@host | invalidPassword |    200 | invalid | zimbraAuthToken |

--- a/src/java/harness/client/HarnessClient.java
+++ b/src/java/harness/client/HarnessClient.java
@@ -34,19 +34,21 @@ public class HarnessClient {
 	}
 
 	public HttpClientBuilder prepareClientBuilder(HttpUriRequest requestBuilder) throws Exception {
-	    factory = new HttpClientFactory().getSocketFactory();
-	    clientBuilder = HttpClientBuilder.create();
+		factory = new HttpClientFactory().getSocketFactory();
+		clientBuilder = HttpClientBuilder.create();
 		clientBuilder.setRedirectStrategy(new LaxRedirectStrategy());
 		clientBuilder.setDefaultCookieStore(cookieStore);
 		clientBuilder.setSSLSocketFactory(factory);
+		SSLContext sslcontext = SSLContexts.custom().useSSL().build();
+		sslcontext.init(null, new X509TrustManager[]{new HttpsTrustManager()}, new SecureRandom());
+		SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(sslcontext,
+				SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+		clientBuilder.setRedirectStrategy(new LaxRedirectStrategy());
+		clientBuilder.setDefaultCookieStore(cookieStore);
+		clientBuilder.setSSLSocketFactory(factory);
+
 		RequestConfig.Builder configBuilder = RequestConfig.custom().setConnectTimeout(TIMEOUT)
 				.setSocketTimeout(TIMEOUT);
-
-		SSLContext sslcontext = SSLContexts.custom().useSSL().build();
-        sslcontext.init(null, new X509TrustManager[]{new HttpsTrustManager()}, new SecureRandom());
-        SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(sslcontext,
-                SSLConnectionSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER);
-
 
 		clientBuilder.setDefaultRequestConfig(configBuilder.build());
 		return clientBuilder;

--- a/src/java/stepDefinitions/AccountStepdefs.java
+++ b/src/java/stepDefinitions/AccountStepdefs.java
@@ -61,7 +61,7 @@ public class AccountStepdefs extends BaseStepDefs {
         context.setResponse(response);
     }
     
-    @Then("^Validate account is created/modified/get with attributes '(.+)'$")
+    @Then("^Validate account has attributes '(.+)'$")
     public void validateAccountAttributes(String attributes) {
         String[] attrs = attributes.split(",");
         for(String current : attrs){
@@ -122,9 +122,8 @@ public class AccountStepdefs extends BaseStepDefs {
         context.setResponse(response);
     }
 
-    @Given("^Create and Delete user account with name '(.+)' password '(.+)'$")
+    @Given("^Delete user account with name '(.+)'$")
     public void deleteAccount(String name, String password) {
-        this.createAccountNoAttrs(name, password);
         String accountIdPath = "data.accountCreate.account.id";
         String accountIdValue = baseline.getValue(context, accountIdPath);
 

--- a/src/java/stepDefinitions/AccountStepdefs.java
+++ b/src/java/stepDefinitions/AccountStepdefs.java
@@ -58,7 +58,7 @@ public class AccountStepdefs extends BaseStepDefs {
         String requestBody = "{" + createMutation + " , " + variables + "}";
 
         HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
-        scenario.write(response.getBody().toString());
+        scenario.write(response.getBody().jsonString());
         context.setResponse(response);
     }
     
@@ -106,7 +106,7 @@ public class AccountStepdefs extends BaseStepDefs {
         String variables = "'variables': " + variable;
         String requestBody = "{" + createMutation + " , " + variables + "}";
         HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
-        scenario.write(response.getBody().toString());
+        scenario.write(response.getBody().jsonString());
         context.setResponse(response);
     }
 
@@ -121,7 +121,7 @@ public class AccountStepdefs extends BaseStepDefs {
         String variables = "'variables': " + variable;
         String requestBody = "{" + modifyMutation + " , " + variables + "}";
         HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
-        scenario.write(response.getBody().toString());
+        scenario.write(response.getBody().jsonString());
         context.setResponse(response);
     }
 
@@ -137,13 +137,12 @@ public class AccountStepdefs extends BaseStepDefs {
         String variables = "'variables': " + variable;
         String requestBody = "{" + deleteAccountMutation + " , " + variables + "}";
         HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
-        scenario.write(response.getBody().toString());
+        scenario.write(response.getBody().jsonString());
         context.setResponse(response);
     }
 
-    @Given("^Create and Get user with name '(.+)' password '(.+)' attribute '(.+)'$")
-    public void getAccount(String name, String password, String attrList) {
-        this.createAccount(name, password, attrList);
+    @Given("^Get user account with name '(.+)' attribute '(.+)'$")
+    public void getAccount(String name, String attrList) {
         String accountNamePath = "data.accountCreate.account.name";
         String accountNameValue = baseline.getValue(context, accountNamePath);
         scenario.write("Actual value in the response: " + accountNameValue);
@@ -157,7 +156,7 @@ public class AccountStepdefs extends BaseStepDefs {
         String variables = "'variables': " + variable;
         String requestBody = "{" + getAccountMutation + " , " + variables + "}";
         HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
-        scenario.write(response.getBody().toString());
+        scenario.write(response.getBody().jsonString());
         context.setResponse(response);
     }
 

--- a/src/java/stepDefinitions/AccountStepdefs.java
+++ b/src/java/stepDefinitions/AccountStepdefs.java
@@ -47,7 +47,7 @@ public class AccountStepdefs extends BaseStepDefs {
         varMap.put("attributes", attributes);
         varMap.put("password", password);
         if(name.contains("host")){
-            String domain = globalProperties.getProperty("server").trim();
+            String domain = globalProperties.getProperty("domain").trim();
             String randomName = name.split("@")[0] + generateRandomInt();
             name = randomName+"@"+domain;
         }
@@ -58,6 +58,7 @@ public class AccountStepdefs extends BaseStepDefs {
         String requestBody = "{" + createMutation + " , " + variables + "}";
 
         HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
+        scenario.write(response.getBody().toString());
         context.setResponse(response);
     }
     
@@ -95,7 +96,7 @@ public class AccountStepdefs extends BaseStepDefs {
         HashMap<String,Object> varMap = new HashMap<String,Object>();
         varMap.put("password", password);
         if(name.contains("host")){
-            String domain = globalProperties.getProperty("server").trim();
+            String domain = globalProperties.getProperty("domain").trim();
             String randomName = name.split("@")[0] + generateRandomInt();
             name = randomName+"@"+domain;
         }
@@ -105,6 +106,7 @@ public class AccountStepdefs extends BaseStepDefs {
         String variables = "'variables': " + variable;
         String requestBody = "{" + createMutation + " , " + variables + "}";
         HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
+        scenario.write(response.getBody().toString());
         context.setResponse(response);
     }
 
@@ -119,6 +121,7 @@ public class AccountStepdefs extends BaseStepDefs {
         String variables = "'variables': " + variable;
         String requestBody = "{" + modifyMutation + " , " + variables + "}";
         HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
+        scenario.write(response.getBody().toString());
         context.setResponse(response);
     }
 
@@ -134,6 +137,7 @@ public class AccountStepdefs extends BaseStepDefs {
         String variables = "'variables': " + variable;
         String requestBody = "{" + deleteAccountMutation + " , " + variables + "}";
         HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
+        scenario.write(response.getBody().toString());
         context.setResponse(response);
     }
 
@@ -152,8 +156,8 @@ public class AccountStepdefs extends BaseStepDefs {
         String variable = var.toJSONString();
         String variables = "'variables': " + variable;
         String requestBody = "{" + getAccountMutation + " , " + variables + "}";
-
         HttpResponse response = baseline.processRequest(context, requestBody, HttpPost.METHOD_NAME);
+        scenario.write(response.getBody().toString());
         context.setResponse(response);
     }
 

--- a/src/java/stepDefinitions/AccountStepdefs.java
+++ b/src/java/stepDefinitions/AccountStepdefs.java
@@ -123,7 +123,7 @@ public class AccountStepdefs extends BaseStepDefs {
     }
 
     @Given("^Delete user account with name '(.+)'$")
-    public void deleteAccount(String name, String password) {
+    public void deleteAccount(String name) {
         String accountIdPath = "data.accountCreate.account.id";
         String accountIdValue = baseline.getValue(context, accountIdPath);
 

--- a/src/java/stepDefinitions/AdminAuthMutationStepDefs.java
+++ b/src/java/stepDefinitions/AdminAuthMutationStepDefs.java
@@ -50,6 +50,10 @@ public class AdminAuthMutationStepDefs extends BaseStepDefs {
         Map<String, Object> authInput = new HashMap<String, Object>();
         Map<String, Object> account = new HashMap<String, Object>();
         Map<String, Object> varMap = new HashMap<String, Object>();
+        if(username.contains("host")){
+            String domain = globalProperties.getProperty("domain").trim();
+            username = username.split("@")[0]+"@"+domain;
+        }
         account.put("accountBy", "name");
         account.put("key", username);
         authInput.put("account", account);

--- a/src/java/stepDefinitions/GenericStepDefs.java
+++ b/src/java/stepDefinitions/GenericStepDefs.java
@@ -34,7 +34,7 @@ public class GenericStepDefs extends BaseStepDefs {
 	public void setURI(String host, String paths) {
 		String server = globalProperties.getProperty("server");
 		String scheme = globalProperties.getProperty("scheme", "https");
-		String port = host.contains("admin") ? globalProperties.getProperty("adminPort") : globalProperties.getProperty("port");
+		String port = host.contains("Admin") ? globalProperties.getProperty("adminPort") : globalProperties.getProperty("port");
 		String path = globalProperties.getProperty(paths);
 		scenario.write("server :" + server);
 		scenario.write("scheme :" + scheme);

--- a/src/java/stepDefinitions/GenericStepDefs.java
+++ b/src/java/stepDefinitions/GenericStepDefs.java
@@ -34,7 +34,7 @@ public class GenericStepDefs extends BaseStepDefs {
 	public void setURI(String host, String paths) {
 		String server = globalProperties.getProperty("server");
 		String scheme = globalProperties.getProperty("scheme", "https");
-		String port = host.contains("admin") ? "7071" : "443";
+		String port = host.contains("admin") ? globalProperties.getProperty("adminPort") : globalProperties.getProperty("port");
 		String path = globalProperties.getProperty(paths);
 		scenario.write("server :" + server);
 		scenario.write("scheme :" + scheme);


### PR DESCRIPTION
Changes made :
1. Admin queries/mutations are sent to admin port
2. Existing steps reused for get and delete mutations
3. Extra logging added
4. Provision made to execute gql automation on lab machines as well as zimbraX setup

Refer report below:
[target.zip](https://github.com/Zimbra/zm-api-test-harness/files/3594916/target.zip)

NOTE: Automation for modify account has failed due to IDBridge issue.